### PR TITLE
fix: delete cookies if the token does not coincide

### DIFF
--- a/server/src/controllers/home.js
+++ b/server/src/controllers/home.js
@@ -51,6 +51,7 @@ async function getUser (req, res) {
 			res.json(JSONResponse)
 		} else {
 			res.sendStatus(401)
+			res.cookie('token', '', { expires: new Date('1969-04-20') })
 		}
 		
 		res.end()
@@ -87,6 +88,7 @@ async function tapUser (req, res) {
 			res.end()
 		} else {
 			res.sendStatus(401)
+			res.cookie('token', '', { expires: new Date('1969-04-20') })
 			res.end()
 		}
 	} catch (error) {

--- a/server/src/controllers/matches.js
+++ b/server/src/controllers/matches.js
@@ -40,12 +40,14 @@ async function likedProfiles (req, res) {
 			} else {
 				// Send the "UNAUTHORIZED" http code
 				res.sendStatus(401)
+				res.cookie('token', '', { expires: new Date('1969-04-20') })
 			}
 
 			// End request
 			res.end()
 		} else {
 			res.sendStatus(401)
+			res.cookie('token', '', { expires: new Date('1969-04-20') })
 			res.end()
 		}
 	} catch (error) {
@@ -86,12 +88,14 @@ async function dislikedProfiles (req, res) {
 			} else {
 				// Send the "UNAUTHORIZED" http code
 				res.sendStatus(401)
+				res.cookie('token', '', { expires: new Date('1969-04-20') })
 			}
 
 			// End request
 			res.end()
 		} else {
 			res.sendStatus(401)
+			res.cookie('token', '', { expires: new Date('1969-04-20') })
 			res.end()
 		}
 	} catch (error) {
@@ -144,12 +148,14 @@ async function matches (req, res) {
 			} else {
 				// Send the "UNAUTHORIZED" http code
 				res.sendStatus(401)
+				res.cookie('token', '', { expires: new Date('1969-04-20') })
 			}
 
 			// End request
 			res.end()
 		} else {
 			res.sendStatus(401)
+			res.cookie('token', '', { expires: new Date('1969-04-20') })
 			res.end()
 		}
 	} catch (error) {

--- a/server/src/controllers/profile.js
+++ b/server/src/controllers/profile.js
@@ -28,6 +28,7 @@ async function getProfileData (req, res) {
 			res.end()
 		} else {
 			res.sendStatus(401)
+			res.cookie('token', '', { expires: new Date('1969-04-20') })
 			res.end()
 		}
 	} catch (error) {
@@ -48,9 +49,9 @@ async function changeAvatar (req, res) {
 			let user = await User.findOne({ name: tokenData.name });
 			
 			// Remove the previous avatar file (if isn't the default one)
-      if (user.avatar !== 'avatar.png') {
-        fs.unlinkSync(path.join(__dirname, `../client/build/avatars/${user.avatar}`))
-      }
+			if (user.avatar !== 'avatar.png') {
+				fs.unlinkSync(path.join(__dirname, `../client/build/avatars/${user.avatar}`))
+			}
 
 			// Save the new avatar name on db
 			user.avatar = req.file.filename;
@@ -61,6 +62,7 @@ async function changeAvatar (req, res) {
 			res.end()
 		} else {
 			res.sendStatus(401)
+			res.cookie('token', '', { expires: new Date('1969-04-20') })
 			res.end()
 		}
 	} catch (error) {
@@ -123,6 +125,7 @@ async function uploadPictures (req, res) {
 			res.end()
 		} else {
 			res.sendStatus(401)
+			res.cookie('token', '', { expires: new Date('1969-04-20') })
 			res.end()
 		}
 	} catch (error) {
@@ -218,6 +221,7 @@ async function deleteAccount (req, res) {
 						res.sendStatus(200)
 					} else {
 						res.sendStatus(401)
+						res.cookie('token', '', { expires: new Date('1969-04-20') })
 					}
 
 					res.end()

--- a/server/src/controllers/user.js
+++ b/server/src/controllers/user.js
@@ -24,6 +24,7 @@ async function getUserData (req, res) {
 			}
 		} else {
 			res.sendStatus(401)
+			res.cookie('token', '', { expires: new Date('1969-04-20') })
 			res.end()
 		}
 	} catch (error) {


### PR DESCRIPTION
If the token does not coincide, return a 401 status code and send an
empty cookie with a dummy expiration date.